### PR TITLE
fix(spacing): fix space in generation

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -156,7 +156,7 @@ new Vue({
                 source += "\n";
 
                 if (data.stats && data.github) {
-                    source += "![GitHub stats](https://github-readme-stats.vercel.app/api?username="+data.github+"&show_icons=true)";
+                    source += "![GitHub stats](https://github-readme-stats.vercel.app/api?username="+data.github+"&show_icons=true)  ";
                 }
                 if (data.views && data.github) {
                     source += "![Profile views](https://gpvc.arturio.dev/"+data.github+")  ";


### PR DESCRIPTION
fix issue with wrong generation where result was all stuck together, like:
`![GitHub stats](https://github-readme-stats.vercel.app/api?username=my_username&show_icons=true)![Profile views](https://gpvc.arturio.dev/my_devto_profile)`

Minor in change, but important in value. :wink: 