### PR TITLE
fix issue with images with dot on cdn.jsdelivr.net

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -86,6 +86,7 @@ new Vue({
         },
         slugify(text) {
             return text.toString().toLowerCase()
+                .replace(/\.+/g, '-dot-')
                 .replace(/\s+/g, '')
                 .replace(/[^\w\-]+/g, '')
                 .replace(/\-\-+/g, '')


### PR DESCRIPTION
On cdn.jsdelivr.net images with a dot in the name: eg: About.me are now called: about-dot-me
So I added a rule in the slugify function to manage them.

.Net is now transformed into dot-net.svg
About.me -> about-dot-me.svg
D3.js -> d3-dot-js.svg