### PR TITLE
Swapped Top Langs and GitHub stats triggers

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -231,13 +231,13 @@ new Vue({
                 }
 
                 if (data.languages && data.github) {
-                    source += "![GitHub stats](https://github-readme-stats.vercel.app/api?username="+data.github+"&show_icons=true)  ";
+                    source += "[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username="+data.github+")](https://github.com/anuraghazra/github-readme-stats)";
                     source += "\n";
                     source += "\n";
                 }
 
                 if (data.stats && data.github) {
-                    source += "[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username="+data.github+")](https://github.com/anuraghazra/github-readme-stats)";
+                    source += "![GitHub stats](https://github-readme-stats.vercel.app/api?username="+data.github+"&show_icons=true)  ";
                     source += "\n";
                     source += "\n";
                 }


### PR DESCRIPTION
The triggers for GitHub Stats and Top languages were adding the wrong images in the markdown.

### Issue

When checking the box for GitHub Stats, the image for top languages appears and when checking the box for Top Languages, the Github Stats appears.

### Fix

The markdown for the 2 images were swapped in the JavaScript since they were in the wrong places.