### PR TITLE
Added support for GitHub metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,6 +268,19 @@
                         </div>
                     </div>
 
+                    <h3 class="mt-3">GitHub Metrics</h3>
+
+                    <p>GitHub username required.</p>
+
+                    <div class="row">
+                        <div class="col-xs-12 col-md-6">
+                            <div class="custom-control custom-checkbox mb-2">
+                                <input type="checkbox" class="custom-control-input" id="customCheck10" v-model="data.metrics">
+                                <label class="custom-control-label" for="customCheck10">Show GitHub metrics</label>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
 
             </app-content>

--- a/js/script.js
+++ b/js/script.js
@@ -39,6 +39,7 @@ new Vue({
 
                 views: false,
                 stats: false,
+                metrics: false,
 
                 languages: false,
                 trophy: false,
@@ -258,7 +259,13 @@ new Vue({
                     source += "\n";
                     source += "\n";
                 }
-		    
+
+                if (data.metrics && data.github) {
+                    source += "![GitHub metrics](https://metrics.lecoq.io/"+data.github+")  ";
+                    source += "\n";
+                    source += "\n";
+                }
+
                 if (data.views && data.github) {
                     source += "![Profile views](https://gpvc.arturio.dev/"+data.github+")  ";
                 }


### PR DESCRIPTION
This add support for [metrics](https://github.com/lowlighter/metrics) in the *Other* panel.

It may be a bit redundant with [anuraghazra/github-readme-stats](https://github.com/anuraghazra/github-readme-stats) since several statistics overlaps, but I guess it could still be revelant for users who would like to show additional metrics about their GitHub account.

Below is a screenshot of what it looks like : 

![image](https://user-images.githubusercontent.com/22963968/95685929-275c7680-0bfb-11eb-8cc6-bebfd8649e6f.png)
